### PR TITLE
TreeId should be zero in Logoff request

### DIFF
--- a/Sources/SMBClient/Misc/BinaryConvertible.swift
+++ b/Sources/SMBClient/Misc/BinaryConvertible.swift
@@ -1,0 +1,8 @@
+//
+//  File.swift
+//  
+//
+//  Created by kishikawa katsumi on 2024/08/03.
+//
+
+import Foundation


### PR DESCRIPTION
TreeId (4 bytes): Uniquely identifies the [tree connect](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/b1b7cc8a-4d24-4701-bc3f-220b543ceef8#gt_c65d1989-3473-4fa9-ac45-6522573823e3) for the command. This MUST be 0 for the [SMB2 TREE_CONNECT Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/832d2130-22e8-4afb-aafd-b30bb0901798). The TreeId can be any unsigned 32-bit integer that is received from a previous [SMB2 TREE_CONNECT Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/dd34e26c-a75e-47fa-aab2-6efc27502e96). TreeId SHOULD be set to 0 for the following commands:

[SMB2 NEGOTIATE Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/e14db7ff-763a-4263-8b10-0c3944f52fc5)

[SMB2 NEGOTIATE Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/63abf97c-0d09-47e2-88d6-6bfa552949a5)

[SMB2 SESSION_SETUP Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/5a3c2c28-d6b0-48ed-b917-a86b2ca4575f)

[SMB2 SESSION_SETUP Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/0324190f-a31b-4666-9fa9-5c624273a694)

[SMB2 LOGOFF Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/abdc4ea9-52df-480e-9a36-34f104797d2c)

[SMB2 LOGOFF Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/7539feb4-6fbb-4996-81ac-06863bb1a89e)

[SMB2 ECHO Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/d939504d-57e2-4c0e-8ad5-1678b6fccca1)

[SMB2 ECHO Response](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/2abe9b3c-c5ab-417f-bcc3-9ab51f2fce35)

[SMB2 CANCEL Request](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-smb2/91913fc6-4ec9-4a83-961b-370070067e63)