### PR TITLE
ci: colima no longer needs to be installed on macOS runners on github…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,16 +8,21 @@ on:
 
 jobs:
   test:
-    runs-on: macos-13
+    runs-on: macos-12
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
       - name: Test
         run: |
           set -ex
-                
-          brew install docker docker-compose colima
-          colima start --runtime docker
+
+          sudo chmod ugo+w /usr/local/bin
+          brew install docker docker-compose lima
+
+          brew install colima
+          colima version
+          colima start --cpu 3 --memory 6 --disk 100 --vm-type=qemu --mount-type=sshfs --dns=1.1.1.1
+          colima restart
 
           docker compose up --detach
 


### PR DESCRIPTION
… actions