### PR TITLE
Download at url with progress

### DIFF
--- a/Sources/SMBClient/FileReader.swift
+++ b/Sources/SMBClient/FileReader.swift
@@ -70,9 +70,14 @@ public class FileReader {
     let fileManger = FileManager.default
     let filePath = localFile.path
     let fileExists = fileManger.fileExists(atPath: filePath)
-    guard let fileHandle = FileHandle(forWritingAtPath: filePath) else {
-          throw URLError(.cannotWriteToFile)
+    // If file does not exist, create an empty file so we can create a FileHandle
+    if !fileExists {
+      try Data().write(to: localFile)
     }
+    guard let fileHandle = FileHandle(forWritingAtPath: filePath) else {
+      throw URLError(.cannotWriteToFile)
+    }
+    // If file did already exist and we are not overriding, throw an error
     if fileExists, !overwrite {
       throw CocoaError(.fileWriteFileExists)
     }

--- a/Sources/SMBClient/SMBClient.swift
+++ b/Sources/SMBClient/SMBClient.swift
@@ -125,6 +125,12 @@ public class SMBClient {
     return data
   }
 
+  public func download(path: String, localPath: URL, overwrite: Bool = false, progressHandler: (_ progress: Double) -> Void = { _ in }) async throws {
+    let fileReader = fileReader(path: Pathname.normalize(path))
+    try await fileReader.download(toLocalFile: localPath, overwrite: overwrite, progressHandler: progressHandler)
+    try await fileReader.close()
+  }
+
   public func upload(content: Data, path: String) async throws {
     try await upload(content: content, path: Pathname.normalize(path), progressHandler: { _ in })
   }

--- a/Tests/SMBClientTests/SMBClientTests.swift
+++ b/Tests/SMBClientTests/SMBClientTests.swift
@@ -390,7 +390,7 @@ final class SMBClientTests: XCTestCase {
     var progressWasUpdated: Bool = false
     let fileManager = FileManager.default
     let tempFolder = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
-    let destinationFile = tempFolder.appending(path: "downloadefile.jpg", directoryHint: .notDirectory)
+    let destinationFile = tempFolder.appending(path: "downloadedfile.jpg", directoryHint: .notDirectory)
     try await client.download(path: path, localPath: destinationFile, overwrite: true) { progress in
         progressWasUpdated = true
     }

--- a/Tests/SMBClientTests/SMBClientTests.swift
+++ b/Tests/SMBClientTests/SMBClientTests.swift
@@ -379,6 +379,28 @@ final class SMBClientTests: XCTestCase {
     XCTAssertEqual(data, try Data(contentsOf: fixtureURL.appending(component: "\(user.sharePath)/\(path)")))
   }
 
+  func testDownloadIntoFile() async throws {
+    let user = bob
+    let client = SMBClient(host: "localhost", port: 4445)
+    try await client.login(username: user.username, password: user.password)
+    try await client.connectShare(user.share)
+
+    let path = "test_files/file_example_JPG_1MB.jpg"
+
+    var progressWasUpdated: Bool = false
+    let fileManager = FileManager.default
+    let tempFolder = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+    let destinationFile = tempFolder.appending(path: "downloadefile.jpg", directoryHint: .notDirectory)
+    try await client.download(path: path, localPath: destinationFile, overwrite: true) { progress in
+        progressWasUpdated = true
+    }
+
+    XCTAssertTrue(fileManager.fileExists(atPath: destinationFile.path))
+    let data = try Data(contentsOf: destinationFile)
+    XCTAssertEqual(data, try Data(contentsOf: fixtureURL.appending(component: "\(user.sharePath)/\(path)")))
+    XCTAssertTrue(progressWasUpdated)
+  }
+
   func testRandomRead01() async throws {
     let user = bob
     let client = SMBClient(host: "localhost", port: 4445)


### PR DESCRIPTION
Downloading large files can be problematic because the `SMBClient.download(path: String)` stores the whole file in memory, returning it as a `Data` object. 

This PR adds a new `SMBClient.download(path: String, localPath: URL, overwrite: Bool, progressHandler: (Double) -> Void)` to allow downloading files while writing the chunks of data to disk progressively, resulting in lower memory consumption. 

- `localPath` accepts a file `URL`, following the existing API in `SMBClient.upload(localPath: URL, remotePath path: String)`
- `overwrite` flag enables overwriting the file if it already exists. If the file does exist and the flag is set to `false`, the download method throws a `CocoaError.fileWriteFileExists` (this is the best error I could find. let me know if there's a better one)
- `progressHandler` allows for download progress updates. It follows the existing progressHandler API in the upload function.

I've also added a test for the new method. 