### PR TITLE
Send a keep-alive request every 300 seconds to avoid router firewall state timeouts.

### DIFF
--- a/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.swift
@@ -104,6 +104,21 @@ class FilesViewController: NSViewController {
       name: FileUpload.didFinish,
       object: nil
     )
+
+    let keepAliveTimer = Timer(timeInterval: 300, repeats: true) { [weak self, treeAccessor, path] (timer) in
+      guard let _ = self else {
+        timer.invalidate()
+        return
+      }
+      Task {
+        do {
+          _ = try await treeAccessor.fileInfo(path: path)
+        } catch {
+          timer.invalidate()
+        }
+      }
+    }
+    RunLoop.main.add(keepAliveTimer, forMode: .common)
   }
 
   override func viewDidAppear() {

--- a/Examples/FileBrowser/FileBrowser.xcodeproj/xcshareddata/xcschemes/FileBrowser (iOS).xcscheme
+++ b/Examples/FileBrowser/FileBrowser.xcodeproj/xcshareddata/xcschemes/FileBrowser (iOS).xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1530"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/Examples/FileBrowser/FileBrowser.xcodeproj/xcshareddata/xcschemes/FileBrowser (macOS).xcscheme
+++ b/Examples/FileBrowser/FileBrowser.xcodeproj/xcshareddata/xcschemes/FileBrowser (macOS).xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1530"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"

--- a/Examples/FileBrowser/FileBrowser.xcodeproj/xcshareddata/xcschemes/FileBrowser (visionOS).xcscheme
+++ b/Examples/FileBrowser/FileBrowser.xcodeproj/xcshareddata/xcschemes/FileBrowser (visionOS).xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1600"
-   version = "1.8">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES"


### PR DESCRIPTION


In my environment, TCP sessions are disconnected by the router after 10 minutes of no communication. Echo requests and TCP keep-alive requests have payloads that are too small and are hardware offloaded, so the timer is not reset.