### PR TITLE
FileBrowser (macOS): resolve Bonjour SRV before SMB login

### DIFF
--- a/Examples/FileBrowser/FileBrowser (macOS)/AuthManager.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/AuthManager.swift
@@ -8,15 +8,19 @@ protocol AuthManager {
 class ServiceAuthManager: AuthManager {
   private let id: ID
   private let service: String
+  private let serviceType: String
+  private let serviceDomain: String
 
   private var authWindowController: ConnectServiceWindowController
   private var authViewController: ConnectServiceViewController
 
   private var session: Session?
 
-  init(id: ID, service: String) {
+  init(id: ID, service: String, type: String, domain: String) {
     self.id = id
     self.service = service
+    self.serviceType = type
+    self.serviceDomain = domain
 
     authWindowController = ConnectServiceWindowController.instantiate()
 
@@ -60,11 +64,16 @@ class ServiceAuthManager: AuthManager {
 
     Task { @MainActor in
       do {
+        let resolved = try await ServiceResolver.resolve(
+          name: service, type: serviceType, domain: serviceDomain
+        )
+
         let sessionManager = SessionManager.shared
         let session = try await sessionManager.login(
           id: id,
-          displayName: nil,
-          server: service,
+          displayName: service,
+          server: resolved.host,
+          port: resolved.port == 445 ? nil : resolved.port,
           username: username,
           password: password,
           savePassword: rememberPassword

--- a/Examples/FileBrowser/FileBrowser (macOS)/ServiceResolver.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/ServiceResolver.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+struct ResolvedService {
+  let host: String
+  let port: Int
+}
+
+enum ServiceResolverError: Error {
+  case timeout
+  case missingHostName
+  case failed([String: NSNumber])
+}
+
+final class ServiceResolver: NSObject, @unchecked Sendable {
+  private var continuation: CheckedContinuation<ResolvedService, Error>?
+  private var netService: NetService?
+  private let lock = NSLock()
+  private var didFinish = false
+
+  static func resolve(
+    name: String,
+    type: String,
+    domain: String,
+    timeout: TimeInterval = 5
+  ) async throws -> ResolvedService {
+    let resolver = ServiceResolver()
+    return try await resolver.start(name: name, type: type, domain: domain, timeout: timeout)
+  }
+
+  private func start(
+    name: String,
+    type: String,
+    domain: String,
+    timeout: TimeInterval
+  ) async throws -> ResolvedService {
+    try await withCheckedThrowingContinuation { (cont: CheckedContinuation<ResolvedService, Error>) in
+      self.continuation = cont
+      DispatchQueue.main.async { [weak self] in
+        guard let self else { return }
+        let service = NetService(domain: domain, type: type, name: name)
+        service.delegate = self
+        self.netService = service
+        service.schedule(in: .main, forMode: .default)
+        service.resolve(withTimeout: timeout)
+      }
+    }
+  }
+
+  private func finish(_ result: Result<ResolvedService, Error>) {
+    lock.lock()
+    if didFinish { lock.unlock(); return }
+    didFinish = true
+    lock.unlock()
+
+    netService?.stop()
+    netService?.delegate = nil
+    netService = nil
+
+    let cont = continuation
+    continuation = nil
+    switch result {
+    case .success(let value): cont?.resume(returning: value)
+    case .failure(let error): cont?.resume(throwing: error)
+    }
+  }
+}
+
+extension ServiceResolver: NetServiceDelegate {
+  func netServiceDidResolveAddress(_ sender: NetService) {
+    var host = sender.hostName ?? ""
+    if host.hasSuffix(".") { host.removeLast() }
+    guard !host.isEmpty else {
+      finish(.failure(ServiceResolverError.missingHostName))
+      return
+    }
+    let port = sender.port > 0 ? sender.port : 445
+    finish(.success(ResolvedService(host: host, port: port)))
+  }
+
+  func netService(_ sender: NetService, didNotResolve errorDict: [String: NSNumber]) {
+    finish(.failure(ServiceResolverError.failed(errorDict)))
+  }
+
+  func netServiceDidStop(_ sender: NetService) {
+    finish(.failure(ServiceResolverError.timeout))
+  }
+}

--- a/Examples/FileBrowser/FileBrowser (macOS)/SidebarManager.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/SidebarManager.swift
@@ -85,7 +85,13 @@ extension SidebarManager {
     if let serverNode = node.content as? ServerNode {
       let authManager: AuthManager
       if serverNode.path.hasSuffix("._smb._tcp.local.") {
-        authManager = ServiceAuthManager(id: serverNode.id, service: serverNode.name)
+        let service = ServiceDiscovery.shared.services.first { $0.id == serverNode.id }
+        authManager = ServiceAuthManager(
+          id: serverNode.id,
+          service: serverNode.name,
+          type: service?.type ?? "_smb._tcp",
+          domain: service?.domain ?? "local."
+        )
       } else {
         authManager = ServerAuthManager(id: serverNode.id)
       }

--- a/Examples/FileBrowser/FileBrowser.xcodeproj/project.pbxproj
+++ b/Examples/FileBrowser/FileBrowser.xcodeproj/project.pbxproj
@@ -62,6 +62,7 @@
 		14529A3C2C3E7724003B035C /* SidebarCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14529A3B2C3E7724003B035C /* SidebarCellView.swift */; };
 		14529A3E2C3E8B5D003B035C /* SessionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14529A3D2C3E8B5D003B035C /* SessionManager.swift */; };
 		14529A402C3EB153003B035C /* AuthManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14529A3F2C3EB153003B035C /* AuthManager.swift */; };
+		14B0E0012E0F00010000ABCD /* ServiceResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14B0E0002E0F00010000ABCD /* ServiceResolver.swift */; };
 		14529A422C3ECAA2003B035C /* Icons.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14529A412C3ECAA2003B035C /* Icons.swift */; };
 		147EC5AE2C3F77D200C08ED3 /* ConnectServer.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 147EC5AD2C3F77D200C08ED3 /* ConnectServer.storyboard */; };
 		147EC5B42C3FCF5B00C08ED3 /* ServerManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 147EC5B32C3FCF5B00C08ED3 /* ServerManager.swift */; };
@@ -145,6 +146,7 @@
 		14529A3B2C3E7724003B035C /* SidebarCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarCellView.swift; sourceTree = "<group>"; };
 		14529A3D2C3E8B5D003B035C /* SessionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionManager.swift; sourceTree = "<group>"; };
 		14529A3F2C3EB153003B035C /* AuthManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthManager.swift; sourceTree = "<group>"; };
+		14B0E0002E0F00010000ABCD /* ServiceResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServiceResolver.swift; sourceTree = "<group>"; };
 		14529A412C3ECAA2003B035C /* Icons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Icons.swift; sourceTree = "<group>"; };
 		147EC5AD2C3F77D200C08ED3 /* ConnectServer.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ConnectServer.storyboard; sourceTree = "<group>"; };
 		147EC5B32C3FCF5B00C08ED3 /* ServerManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ServerManager.swift; sourceTree = "<group>"; };
@@ -286,6 +288,7 @@
 				145299E62C3AC3DD003B035C /* DocumentWindowController.swift */,
 				145299AF2C3A5C0B003B035C /* MediaPlayerWindowController.swift */,
 				14529A3F2C3EB153003B035C /* AuthManager.swift */,
+				14B0E0002E0F00010000ABCD /* ServiceResolver.swift */,
 				14529A3D2C3E8B5D003B035C /* SessionManager.swift */,
 				145299922C34D523003B035C /* SidebarManager.swift */,
 				144680352C349C0C0029A1AB /* Tree.swift */,
@@ -530,6 +533,7 @@
 				145299E72C3AC3DD003B035C /* DocumentWindowController.swift in Sources */,
 				144680362C349C0C0029A1AB /* Tree.swift in Sources */,
 				14529A402C3EB153003B035C /* AuthManager.swift in Sources */,
+				14B0E0012E0F00010000ABCD /* ServiceResolver.swift in Sources */,
 				147EC5BE2C41019400C08ED3 /* ActivityCell.swift in Sources */,
 				14529A422C3ECAA2003B035C /* Icons.swift in Sources */,
 				14529A3A2C3E23C6003B035C /* PathBarView.swift in Sources */,

--- a/Examples/FileBrowser/FileBrowser.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Examples/FileBrowser/FileBrowser.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -16,7 +16,7 @@
       "location" : "https://github.com/kishikawakatsumi/SMBClient.git",
       "state" : {
         "branch" : "main",
-        "revision" : "b045d2d9504963ac0e4058675ee976233035c4f2"
+        "revision" : "e129ddc6f0cfb97f0189e1e38cc9332ee88e159d"
       }
     }
   ],


### PR DESCRIPTION
NWBrowser hands back the service instance name, which can differ from the host's LocalHostName and therefore not resolve via mDNS. Resolve the SRV record before opening SMBClient so the actual reachable host:port is used.

- Add ServiceResolver wrapping NetService.resolve(withTimeout:)
- ServiceAuthManager now takes (name, type, domain) and resolves before login; falls back to default port when 445
- SidebarManager looks up the discovered Service by id to recover the type/domain triple