### PR TITLE
FileBrowser (macOS): rebrand app to SMBeam

### DIFF
--- a/Examples/FileBrowser/FileBrowser (macOS)/Base.lproj/Main.storyboard
+++ b/Examples/FileBrowser/FileBrowser (macOS)/Base.lproj/Main.storyboard
@@ -14,11 +14,11 @@
                 <application id="hnw-xV-0zn" sceneMemberID="viewController">
                     <menu key="mainMenu" title="Main Menu" systemMenu="main" id="AYu-sK-qS6">
                         <items>
-                            <menuItem title="File Browser" id="1Xt-HY-uBw">
+                            <menuItem title="SMBeam" id="1Xt-HY-uBw">
                                 <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="File Browser" systemMenu="apple" id="uQy-DD-JDr">
+                                <menu key="submenu" title="SMBeam" systemMenu="apple" id="uQy-DD-JDr">
                                     <items>
-                                        <menuItem title="About File Browser" id="5kV-Vb-QxS">
+                                        <menuItem title="About SMBeam" id="5kV-Vb-QxS">
                                             <modifierMask key="keyEquivalentModifierMask"/>
                                             <connections>
                                                 <action selector="orderFrontStandardAboutPanel:" target="Ady-hI-5gd" id="Exp-CZ-Vem"/>
@@ -32,7 +32,7 @@
                                             <menu key="submenu" title="Services" systemMenu="services" id="hz9-B4-Xy5"/>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="4je-JR-u6R"/>
-                                        <menuItem title="Hide File Browser" keyEquivalent="h" id="Olw-nP-bQN">
+                                        <menuItem title="Hide SMBeam" keyEquivalent="h" id="Olw-nP-bQN">
                                             <connections>
                                                 <action selector="hide:" target="Ady-hI-5gd" id="PnN-Uc-m68"/>
                                             </connections>
@@ -50,7 +50,7 @@
                                             </connections>
                                         </menuItem>
                                         <menuItem isSeparatorItem="YES" id="kCx-OE-vgT"/>
-                                        <menuItem title="Quit File Browser" keyEquivalent="q" id="4sb-4s-VLi">
+                                        <menuItem title="Quit SMBeam" keyEquivalent="q" id="4sb-4s-VLi">
                                             <connections>
                                                 <action selector="terminate:" target="Ady-hI-5gd" id="Te7-pn-YzF"/>
                                             </connections>
@@ -212,7 +212,7 @@ CA
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Help" systemMenu="help" id="F2S-fz-NVQ">
                                     <items>
-                                        <menuItem title="File Browser Help" keyEquivalent="?" id="FKE-Sm-Kum">
+                                        <menuItem title="SMBeam Help" keyEquivalent="?" id="FKE-Sm-Kum">
                                             <connections>
                                                 <action selector="showHelp:" target="Ady-hI-5gd" id="y7X-2Q-9no"/>
                                             </connections>

--- a/Examples/FileBrowser/FileBrowser (macOS)/Info.plist
+++ b/Examples/FileBrowser/FileBrowser (macOS)/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDisplayName</key>
+	<string>SMBeam</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 </dict>

--- a/Examples/FileBrowser/FileBrowser.xcodeproj/project.pbxproj
+++ b/Examples/FileBrowser/FileBrowser.xcodeproj/project.pbxproj
@@ -115,7 +115,7 @@
 		14288FAD2CF87E800059EA58 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		14288FAE2CF87E800059EA58 /* SharesView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharesView.swift; sourceTree = "<group>"; };
 		14288FAF2CF87E800059EA58 /* VideoPlayerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPlayerView.swift; sourceTree = "<group>"; };
-		144680172C347E1F0029A1AB /* File Browser.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "File Browser.app"; sourceTree = BUILT_PRODUCTS_DIR; };
+		144680172C347E1F0029A1AB /* SMBeam.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SMBeam.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1446801A2C347E1F0029A1AB /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1446801E2C347E200029A1AB /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		144680212C347E200029A1AB /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
@@ -262,7 +262,7 @@
 		144680182C347E1F0029A1AB /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				144680172C347E1F0029A1AB /* File Browser.app */,
+				144680172C347E1F0029A1AB /* SMBeam.app */,
 				14C23C802C53962F00CEA8CF /* File Browser.app */,
 				14F80F742CEA933D00C1869A /* File Browser.app */,
 			);
@@ -372,7 +372,7 @@
 				14F80FD92CEA974200C1869A /* FlyingSocks */,
 			);
 			productName = FileBrowser;
-			productReference = 144680172C347E1F0029A1AB /* File Browser.app */;
+			productReference = 144680172C347E1F0029A1AB /* SMBeam.app */;
 			productType = "com.apple.product-type.application";
 		};
 		14C23C7F2C53962F00CEA8CF /* FileBrowser (iOS) */ = {
@@ -762,7 +762,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kishikawakatsumi.FileBrowser;
 				PRODUCT_MODULE_NAME = FileBrowser;
-				PRODUCT_NAME = "File Browser";
+				PRODUCT_NAME = SMBeam;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};
@@ -792,7 +792,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.kishikawakatsumi.FileBrowser;
 				PRODUCT_MODULE_NAME = FileBrowser;
-				PRODUCT_NAME = "File Browser";
+				PRODUCT_NAME = SMBeam;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};

--- a/Examples/FileBrowser/FileBrowser.xcodeproj/xcshareddata/xcschemes/FileBrowser (macOS).xcscheme
+++ b/Examples/FileBrowser/FileBrowser.xcodeproj/xcshareddata/xcschemes/FileBrowser (macOS).xcscheme
@@ -16,7 +16,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "144680162C347E1F0029A1AB"
-               BuildableName = "File Browser.app"
+               BuildableName = "SMBeam.app"
                BlueprintName = "FileBrowser (macOS)"
                ReferencedContainer = "container:FileBrowser.xcodeproj">
             </BuildableReference>
@@ -45,7 +45,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "144680162C347E1F0029A1AB"
-            BuildableName = "File Browser.app"
+            BuildableName = "SMBeam.app"
             BlueprintName = "FileBrowser (macOS)"
             ReferencedContainer = "container:FileBrowser.xcodeproj">
          </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "144680162C347E1F0029A1AB"
-            BuildableName = "File Browser.app"
+            BuildableName = "SMBeam.app"
             BlueprintName = "FileBrowser (macOS)"
             ReferencedContainer = "container:FileBrowser.xcodeproj">
          </BuildableReference>


### PR DESCRIPTION
- Set PRODUCT_NAME to SMBeam (drives CFBundleName, CFBundleExecutable, and the built .app filename)
- Add CFBundleDisplayName=SMBeam to Info.plist
- Update macOS productReference to SMBeam.app in project.pbxproj
- Rename main menu items in Main.storyboard: File Browser / About / Hide / Quit / Help → SMBeam variants

iOS and visionOS targets are intentionally left as "File Browser".