### PR TITLE
FileBrowser (macOS): fix crash when clearing the activities list

### DIFF
--- a/Examples/FileBrowser/FileBrowser (macOS)/ActivitiesViewController.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/ActivitiesViewController.swift
@@ -53,11 +53,16 @@ class ActivitiesViewController: NSViewController {
 
   @IBAction
   private func clearActivities(_ sender: NSSegmentedControl) {
+    // Snapshot the row count *before* mutating the model — `numberOfRows(in:)`
+    // is data-source backed, so it would otherwise change underneath us mid-loop
+    // and produce the wrong reverse-mapped row indices (and, when more than one
+    // entry needed removing, an `Invalid update:` assertion crash).
+    let oldRowCount = tableView.numberOfRows
     let deleted = TransferQueue.shared.clearFinishedTransfers()
+    guard !deleted.isEmpty else { return }
 
-    for index in deleted {
-      tableView.removeRows(at: [tableView.numberOfRows - 1 - index])
-    }
+    let rowsToRemove = IndexSet(deleted.map { oldRowCount - 1 - $0 })
+    tableView.removeRows(at: rowsToRemove, withAnimation: .effectFade)
   }
 }
 


### PR DESCRIPTION
The Clear button removed rows one by one, recomputing `tableView.numberOfRows - 1 - index` each iteration. Two issues combined:

- The model (`TransferQueue.transfers`) was already shrunk by `clearFinishedTransfers()` before any `removeRows(at:)` call, so `numberOfRows(in:)` reported the new count while the table was still tracking the old one. After the first removal, NSTableView's internal validation found the data source out of sync and asserted with `Invalid update:`.
- `tableView.numberOfRows` decremented per call, so the reverse- mapped row index for the second and subsequent deletions was pointing at the wrong rows (or going negative).

Single completed entries happened to dodge both problems, which is why the crash only showed up when two or more completed transfers were cleared at once.

Snapshot `tableView.numberOfRows` before mutating the model, map all deleted model indices to row indices in one go, and remove them with a single `removeRows(at: IndexSet, withAnimation: .effectFade)`.