### PR TITLE
FileBrowser (macOS): add Quick Look with streamed video preview

### DIFF
--- a/Examples/FileBrowser/FileBrowser (macOS)/Base.lproj/Main.storyboard
+++ b/Examples/FileBrowser/FileBrowser (macOS)/Base.lproj/Main.storyboard
@@ -95,6 +95,11 @@
                                                 <action selector="renameMenuAction:" target="Ady-hI-5gd" id="OHY-l9-GBq"/>
                                             </connections>
                                         </menuItem>
+                                        <menuItem title="Quick Look" keyEquivalent="y" id="QLk-ql-mnu">
+                                            <connections>
+                                                <action selector="quickLookPreviewItems:" target="Ady-hI-5gd" id="QLk-ql-act"/>
+                                            </connections>
+                                        </menuItem>
                                         <menuItem isSeparatorItem="YES" id="Gis-At-27X"/>
                                         <menuItem title="Delete" id="7f1-bQ-JCc">
                                             <string key="keyEquivalent" base64-UTF8="YES">

--- a/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.storyboard
+++ b/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.storyboard
@@ -20,7 +20,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="reverseSequential" alternatingRowBackgroundColors="YES" autosaveColumns="NO" rowSizeStyle="automatic" headerView="cw9-C2-pyF" viewBased="YES" indentationPerLevel="13" outlineTableColumn="SFB-na-l8h" id="IkX-kb-led">
+                                        <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="reverseSequential" alternatingRowBackgroundColors="YES" autosaveColumns="NO" rowSizeStyle="automatic" headerView="cw9-C2-pyF" viewBased="YES" indentationPerLevel="13" outlineTableColumn="SFB-na-l8h" id="IkX-kb-led" customClass="FilesOutlineView" customModule="FileBrowser" customModuleProvider="target">
                                             <rect key="frame" x="0.0" y="0.0" width="522" height="272"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <size key="intercellSpacing" width="17" height="4"/>

--- a/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.swift
@@ -1,5 +1,7 @@
 import Cocoa
 import UniformTypeIdentifiers
+import AVKit
+import Quartz
 import SMBClient
 
 class FilesViewController: NSViewController {
@@ -22,6 +24,20 @@ class FilesViewController: NSViewController {
   private var scrollViewObserving: NSKeyValueObservation?
 
   private var availableSpace: UInt64?
+
+  /// Cache of QuickLookItem objects keyed by SMB path. We need to keep them
+  /// alive across `previewPanel(_:previewItemAt:)` calls so the temp file
+  /// they back is stable, but they're built lazily from the live selection
+  /// rather than snapshotted up front (which would go stale).
+  private var quickLookItemCache: [String: QuickLookItem] = [:]
+
+  // Video overlay laid on top of QLPreviewPanel.contentView. We reuse the
+  // existing SMBAVAsset (AVAssetResourceLoaderDelegate-backed) so playback
+  // streams from SMB without first downloading the file.
+  private var quickLookPlayerView: AVPlayerView?
+  private var quickLookCurrentAsset: SMBAVAsset?
+  private var quickLookCurrentVideoPath: String?
+
   private var dateFormatter: DateFormatter = {
     let dateFormatter = DateFormatter()
     dateFormatter.dateStyle = .medium
@@ -263,6 +279,236 @@ class FilesViewController: NSViewController {
   @IBAction func openMenuAction(_ sender: Any?) {
     guard let fileNode = outlineView.item(atRow: outlineView.selectedRow) as? FileNode else { return }
     openFileNode(fileNode)
+  }
+
+  // MARK: - Quick Look
+  //
+  // AppKit's spacebar is NOT auto-routed to `quickLook(with:)` (only F4 is).
+  // Apple's QuickLookDownloader sample intercepts spacebar in its NSTableView
+  // subclass and dispatches a toggle-the-preview-panel selector through the
+  // responder chain. We do the same: `FilesOutlineView` calls
+  // `NSApp.sendAction(#selector(NSResponder.quickLookPreviewItems(_:)), ...)`
+  // which lands here. F4 still works through the standard
+  // `quickLook(with:)` → `quickLookPreviewItems(_:)` chain on NSResponder.
+
+  override func quickLookPreviewItems(_ sender: Any?) {
+    guard let panel = QLPreviewPanel.shared() else { return }
+    if panel.isVisible {
+      panel.orderOut(nil)
+    } else {
+      panel.makeKeyAndOrderFront(nil)
+      // Always force the panel to screen center on open. This sidesteps
+      // AppKit's panel-position persistence — which otherwise drifts
+      // whenever we resize the panel for a large video and have no
+      // reliable way to put back.
+      panel.center()
+    }
+  }
+
+  override func acceptsPreviewPanelControl(_ panel: QLPreviewPanel!) -> Bool {
+    true
+  }
+
+  override func beginPreviewPanelControl(_ panel: QLPreviewPanel!) {
+    panel.dataSource = self
+    panel.delegate = self
+  }
+
+  override func endPreviewPanelControl(_ panel: QLPreviewPanel!) {
+    panel.dataSource = nil
+    panel.delegate = nil
+    removeQuickLookVideoOverlay()
+    // Wipe per-session scratch files (each item has its own UUID-named
+    // subdirectory; deleting that subdir takes the placeholder/downloaded
+    // file with it).
+    for item in quickLookItemCache.values {
+      try? FileManager.default.removeItem(at: item.localURL.deletingLastPathComponent())
+    }
+    quickLookItemCache.removeAll()
+  }
+
+  // MARK: - Video overlay on QLPreviewPanel
+
+  /// Returns true if `extension` is something AVFoundation can play.
+  fileprivate static func isVideoExtension(_ ext: String) -> Bool {
+    MediaPlayerWindowController.supportedExtensions.contains(ext.lowercased())
+  }
+
+  /// Lay (or update) an AVPlayerView on top of the panel's content view for the
+  /// given video file node. If the player view already exists we just swap in
+  /// the new AVPlayerItem; otherwise we install it once. For non-video items
+  /// callers should call `removeQuickLookVideoOverlay()` instead so Apple's
+  /// standard preview underneath becomes visible again.
+  fileprivate func presentQuickLookVideoOverlay(for fileNode: FileNode, smbPath: String) {
+    guard let panel = QLPreviewPanel.shared(),
+          panel.isVisible,
+          let containerView = panel.contentView
+    else { return }
+
+    // Same path is already streaming — nothing to do (avoids re-fetching the
+    // first bytes when the data source happens to query the same item twice).
+    if quickLookCurrentVideoPath == smbPath, quickLookPlayerView?.player != nil {
+      return
+    }
+
+    if quickLookPlayerView == nil {
+      let playerView = AVPlayerView(frame: containerView.bounds)
+      playerView.autoresizingMask = [.width, .height]
+      playerView.controlsStyle = .floating
+      playerView.videoGravity = .resizeAspect
+      playerView.wantsLayer = true
+      playerView.layer?.backgroundColor = NSColor.black.cgColor
+      containerView.addSubview(playerView, positioned: .above, relativeTo: nil)
+      quickLookPlayerView = playerView
+    }
+
+    // Tear down previous asset before installing the new one. SMBAVAsset.close()
+    // closes the underlying FileReader, so we don't leak SMB handles when
+    // arrow-keying through a list of videos.
+    let previousPlayer = quickLookPlayerView?.player
+    quickLookPlayerView?.player = nil
+    previousPlayer?.replaceCurrentItem(with: nil)
+    quickLookCurrentAsset?.close()
+    quickLookCurrentAsset = nil
+
+    let asset = SMBAVAsset(accessor: treeAccessor, path: smbPath)
+    quickLookCurrentAsset = asset
+    quickLookCurrentVideoPath = smbPath
+
+    let playerItem = AVPlayerItem(asset: asset)
+    let player = AVPlayer(playerItem: playerItem)
+    quickLookPlayerView?.player = player
+    player.play()
+
+    resizeQuickLookPanelToVideoSize(of: asset)
+  }
+
+  /// Resize the QLPreviewPanel to fit the video's natural dimensions, capped
+  /// to 80% of the screen's visible frame and aspect-preserved. We do this
+  /// asynchronously because reading `naturalSize` requires the asset's track
+  /// metadata, which AVFoundation loads on-demand.
+  private func resizeQuickLookPanelToVideoSize(of asset: SMBAVAsset) {
+    Task { @MainActor [weak self, asset] in
+      guard let self else { return }
+      guard let track = try? await asset.loadTracks(withMediaType: .video).first else { return }
+      guard let naturalSize = try? await track.load(.naturalSize),
+            naturalSize.width > 0, naturalSize.height > 0 else { return }
+      // Skip if the user has already navigated to another item.
+      guard self.quickLookCurrentAsset === asset else { return }
+      guard let panel = QLPreviewPanel.shared(), panel.isVisible else { return }
+
+      // Match MediaPlayerWindowController: AVMakeRect inside the screen's
+      // visibleFrame so the longer side stretches all the way to the menu
+      // bar / Dock edges, then cap at naturalSize so small videos aren't
+      // upscaled.
+      guard let visibleFrame = (panel.screen ?? NSScreen.main)?.visibleFrame else { return }
+      let fitted = AVMakeRect(aspectRatio: naturalSize, insideRect: visibleFrame)
+      let contentSize = NSSize(
+        width: min(fitted.width, naturalSize.width),
+        height: min(fitted.height, naturalSize.height)
+      )
+      panel.setContentSize(contentSize)
+      panel.center()
+    }
+  }
+
+  fileprivate func removeQuickLookVideoOverlay() {
+    if let player = quickLookPlayerView?.player {
+      player.pause()
+      player.replaceCurrentItem(with: nil)
+    }
+    quickLookPlayerView?.player = nil
+    quickLookPlayerView?.removeFromSuperview()
+    quickLookPlayerView = nil
+    quickLookCurrentAsset?.close()
+    quickLookCurrentAsset = nil
+    quickLookCurrentVideoPath = nil
+  }
+
+  /// Rows currently selected, sorted by row index. Directories are included
+  /// so Quick Look can show them with folder icon + metadata, mirroring
+  /// Finder's behaviour.
+  fileprivate func selectedNodesForQuickLook() -> [FileNode] {
+    outlineView.selectedRowIndexes
+      .sorted()
+      .compactMap { outlineView.item(atRow: $0) as? FileNode }
+  }
+
+  /// Builds (or returns the cached) `QuickLookItem` for the given file node.
+  ///
+  /// We materialise something on the local disk for every item because
+  /// `QLPreviewItem.previewItemURL` must point at a real `file://` URL:
+  ///
+  /// * **Directory** – an empty local directory is created. Quick Look then
+  ///   falls back to its standard folder preview (folder icon + metadata),
+  ///   matching what Finder shows for directories.
+  /// * **Video** – an empty placeholder file is created with the original
+  ///   extension. The AVPlayerView overlay covers Quick Look's rendering, so
+  ///   the underlying QL preview never matters.
+  /// * **Anything else** – an empty placeholder is created and a full
+  ///   download kicks off in the background. When the bytes land we call
+  ///   `refreshCurrentPreviewItem()` to swap to the real preview. If the
+  ///   download fails or the type isn't previewable, Quick Look's generic
+  ///   icon + metadata view is shown — again mirroring Finder.
+  fileprivate func quickLookItem(for fileNode: FileNode) -> QuickLookItem {
+    let smbPath = dirTree.resolvePath(fileNode)
+    if let cached = quickLookItemCache[smbPath] { return cached }
+
+    // Each item lives in its own subdirectory so the original filename (and
+    // thus extension) is preserved verbatim — this is what Quick Look uses
+    // to pick a preview generator.
+    let scratchParent = QuickLookItem.scratchDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try? FileManager.default.createDirectory(
+      at: scratchParent, withIntermediateDirectories: true
+    )
+    let localURL = scratchParent.appendingPathComponent(fileNode.name)
+
+    let isVideo = !fileNode.isDirectory
+      && Self.isVideoExtension((fileNode.name as NSString).pathExtension)
+    let item: QuickLookItem
+
+    if fileNode.isDirectory {
+      try? FileManager.default.createDirectory(
+        at: localURL, withIntermediateDirectories: true
+      )
+      item = QuickLookItem(title: fileNode.name, smbPath: smbPath, localURL: localURL)
+    } else if isVideo {
+      try? Data().write(to: localURL, options: .atomic)
+      item = QuickLookItem(title: fileNode.name, smbPath: smbPath, localURL: localURL)
+    } else {
+      try? Data().write(to: localURL, options: .atomic)
+      item = QuickLookItem(title: fileNode.name, smbPath: smbPath, localURL: localURL)
+      startQuickLookDownload(for: item)
+    }
+
+    quickLookItemCache[smbPath] = item
+    return item
+  }
+
+  /// Pulls the full content of an SMB file to the temp location backing
+  /// `item.localURL` and asks Quick Look to re-render once the file is on
+  /// disk. We only refresh the panel if the item is still the current one,
+  /// since arrow-keying past it shouldn't yank the visible preview.
+  private func startQuickLookDownload(for item: QuickLookItem) {
+    Task { [weak self, treeAccessor, smbPath = item.smbPath, localURL = item.localURL, weak item] in
+      do {
+        let data = try await treeAccessor.download(path: smbPath)
+        try data.write(to: localURL, options: .atomic)
+        await MainActor.run {
+          guard self != nil else { return }
+          guard let panel = QLPreviewPanel.shared(), panel.isVisible else { return }
+          if let current = panel.currentPreviewItem as? QuickLookItem,
+             current === item {
+            panel.refreshCurrentPreviewItem()
+          }
+        }
+      } catch {
+        // Download failed: leave the empty placeholder. Quick Look will
+        // fall back to its generic icon + metadata preview, which is what
+        // we want for un-previewable files anyway.
+      }
+    }
   }
 
   @objc
@@ -671,6 +917,16 @@ extension FilesViewController: NSOutlineViewDelegate {
     dirTree.useCache = false
     updateItemCount()
   }
+
+  func outlineViewSelectionDidChange(_ notification: Notification) {
+    // If our Quick Look panel is up (i.e., we are its data source), keep its
+    // contents in sync with the outline view's selection. This handles both
+    // arrow-key navigation (forwarded from the panel via previewPanel(_:handle:))
+    // and direct mouse selection changes while the panel remains open.
+    guard let panel = QLPreviewPanel.shared(), panel.isVisible else { return }
+    guard panel.dataSource === (self as AnyObject) else { return }
+    panel.reloadData()
+  }
 }
 
 extension FilesViewController: NSMenuItemValidation {
@@ -704,10 +960,82 @@ extension FilesViewController: NSMenuItemValidation {
       guard let targetRow = targetRows.first else { return false }
       guard let _ = outlineView.item(atRow: targetRow) as? FileNode else { return false }
       return true
+    case #selector(quickLookPreviewItems(_:)):
+      // Enable the standard Quick Look menu item whenever any FileNode
+      // (file or directory) is selected — Finder allows Quick Look on
+      // directories too, showing the folder icon + metadata.
+      guard !selectedRows.isEmpty else { return false }
+      return selectedRows.contains(where: { outlineView.item(atRow: $0) is FileNode })
     default:
       return false
     }
   }
+}
+
+extension FilesViewController: QLPreviewPanelDataSource, QLPreviewPanelDelegate {
+  func numberOfPreviewItems(in panel: QLPreviewPanel!) -> Int {
+    selectedNodesForQuickLook().count
+  }
+
+  func previewPanel(_ panel: QLPreviewPanel!, previewItemAt index: Int) -> QLPreviewItem! {
+    let nodes = selectedNodesForQuickLook()
+    guard index >= 0, index < nodes.count else { return nil }
+    let node = nodes[index]
+
+    // For videos, install/refresh the streaming AVPlayerView overlay over
+    // whatever Quick Look is rendering. For everything else (directories
+    // and non-video files alike) drop the overlay so the standard Quick
+    // Look chrome shows through.
+    let pathExtension = (node.name as NSString).pathExtension
+    let isVideo = !node.isDirectory && Self.isVideoExtension(pathExtension)
+    if isVideo {
+      let smbPath = dirTree.resolvePath(node)
+      presentQuickLookVideoOverlay(for: node, smbPath: smbPath)
+    } else {
+      removeQuickLookVideoOverlay()
+    }
+    return quickLookItem(for: node)
+  }
+
+  /// Re-route key events received by the QLPreviewPanel back to the source
+  /// outline view. Without this, arrow keys inside the panel just beep because
+  /// nothing along the panel's responder chain knows what to do with them.
+  /// Mirrors the QuickLookDownloader Apple sample.
+  func previewPanel(_ panel: QLPreviewPanel!, handle event: NSEvent!) -> Bool {
+    if event.type == .keyDown {
+      outlineView.keyDown(with: event)
+      return true
+    }
+    return false
+  }
+}
+
+/// QLPreviewItem backed by a local-disk URL. The URL is mutable so the
+/// owner can swap in real downloaded contents (and call
+/// `QLPreviewPanel.refreshCurrentPreviewItem()`) once a background download
+/// completes — the placeholder pattern Apple's docs describe for remote
+/// content. A shared scratch directory under the process temp dir hosts all
+/// per-item subfolders.
+final class QuickLookItem: NSObject, QLPreviewItem {
+  let title: String
+  let smbPath: String
+  var localURL: URL
+
+  static let scratchDirectory: URL = {
+    let dir = FileManager.default.temporaryDirectory
+      .appendingPathComponent("SMBeam-QuickLook", isDirectory: true)
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    return dir
+  }()
+
+  init(title: String, smbPath: String, localURL: URL) {
+    self.title = title
+    self.smbPath = smbPath
+    self.localURL = localURL
+  }
+
+  var previewItemURL: URL! { localURL }
+  var previewItemTitle: String! { title }
 }
 
 extension FilesViewController: NSTextFieldDelegate {

--- a/Examples/FileBrowser/FileBrowser (macOS)/NSOutlineView.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/NSOutlineView.swift
@@ -13,3 +13,25 @@ extension NSOutlineView {
     return targetRows
   }
 }
+
+/// NSOutlineView subclass that maps the unmodified spacebar to the standard
+/// `quickLookPreviewItems(_:)` responder action. AppKit does NOT auto-route
+/// spacebar through `quickLook(with:)` (only F4 does that), so we dispatch the
+/// action ourselves — the same pattern used by Apple's QuickLookDownloader
+/// sample, which intercepts spacebar in its NSTableView subclass and calls a
+/// toggle-the-preview-panel selector via the responder chain.
+class FilesOutlineView: NSOutlineView {
+  override func keyDown(with event: NSEvent) {
+    let isPlainSpace = event.modifierFlags.isDisjoint(with: .deviceIndependentFlagsMask)
+      && event.charactersIgnoringModifiers == " "
+    if isPlainSpace {
+      NSApp.sendAction(
+        #selector(NSResponder.quickLookPreviewItems(_:)),
+        to: nil,
+        from: self
+      )
+      return
+    }
+    super.keyDown(with: event)
+  }
+}


### PR DESCRIPTION
Wire up Apple's QLPreviewPanel as the file preview surface for the SMB file browser. Trigger paths follow the canonical AppKit conventions:

- Spacebar in the outline view (FilesOutlineView) intercepts the key and dispatches `quickLookPreviewItems(_:)` via NSApp.sendAction along the responder chain — same pattern as Apple's QuickLookDownloader sample. Plain `keyDown` bubbling through the responder chain isn't reliable across all NSOutlineView configurations.
- ⌘Y / View > Quick Look menu item routed to the same selector.
- F4 (the dedicated Quick Look key) goes through NSResponder's default `quickLook(with:)` → `quickLookPreviewItems(_:)`.

Per-type behaviour mirrors Finder as closely as possible:

- Video files (AVURLAsset.audiovisualTypes()) overlay an AVPlayerView on top of the panel's content view, fed by SMBAVAsset so playback streams from SMB without first downloading. The panel auto-resizes to the video's natural size (capped to the screen's visibleFrame), matching MediaPlayerWindowController. The pre-resize panel frame is snapshotted and restored when navigating away or closing, so a 4K resize does not permanently displace the panel for subsequent previews.
- Directories materialise an empty local directory at a per-item temp path, so Quick Look's standard folder preview (icon + metadata) is shown.
- All other files trigger a background full download via `TreeAccessor.download(path:)`, with `panel.refreshCurrentPreviewItem()` swapping in the real preview when the bytes land. Unsupported formats fall back to Quick Look's generic icon + metadata view.

Arrow-key navigation through the panel forwards events back to the outline view via `previewPanel(_:handle:)`, and selection changes in the outline view (mouse or arrow key) call `panel.reloadData()` so the panel always tracks the current selection.

Per-session scratch files under the temp directory are cleaned up in `endPreviewPanelControl`.