### PR TITLE
FileBrowser (macOS): open in new tab on Cmd-click

### DIFF
--- a/Examples/FileBrowser/FileBrowser (macOS)/AppDelegate.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/AppDelegate.swift
@@ -115,4 +115,39 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     guard let index = windowControllers.firstIndex(where: { $0.window == window }) else { return }
     windowControllers.remove(at: index)
   }
+
+  /// Create a fresh WindowController, push the given view controller on top of
+  /// its empty navigation stack, then attach it as a tab to `existingWindow`.
+  /// Returns the new window controller (already retained by the AppDelegate).
+  /// Used by Cmd-click in the file list and the sidebar to open the destination
+  /// in a new tab, mirroring Finder's "open in new tab" gesture.
+  @discardableResult
+  func openInNewTab(
+    adjacentTo existingWindow: NSWindow?,
+    configure: (NavigationController) -> Void
+  ) -> WindowController? {
+    guard
+      let windowController = NSStoryboard(name: "Main", bundle: nil)
+        .instantiateInitialController() as? WindowController,
+      let newWindow = windowController.window,
+      let split = windowController.contentViewController as? SplitViewController,
+      let nav = split.splitViewItems[safe: 1]?.viewController as? NavigationController
+    else { return nil }
+
+    configure(nav)
+
+    if let existingWindow {
+      existingWindow.addTabbedWindow(newWindow, ordered: .above)
+    }
+    newWindow.makeKeyAndOrderFront(nil)
+
+    windowControllers.append(windowController)
+    return windowController
+  }
+}
+
+private extension Array {
+  subscript(safe index: Int) -> Element? {
+    indices.contains(index) ? self[index] : nil
+  }
 }

--- a/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.swift
@@ -282,18 +282,33 @@ class FilesViewController: NSViewController {
 
   private func openFileNode(_ fileNode: FileNode) {
     if fileNode.isDirectory {
-      guard let navigationController = navigationController() else { return }
-
       let treeAccessor = self.treeAccessor
       let path = dirTree.resolvePath(fileNode)
       let rootPath = self.rootPath
+      let serverNode = self.serverNode
+      let share = self.share
+      let title = fileNode.name
 
-      let filesViewController = FilesViewController.instantiate(
-        accessor: treeAccessor, serverNode: serverNode, share: share, path: path, rootPath: rootPath
-      )
-      filesViewController.title = fileNode.name
+      let makeFilesViewController: () -> FilesViewController = {
+        let vc = FilesViewController.instantiate(
+          accessor: treeAccessor, serverNode: serverNode, share: share, path: path, rootPath: rootPath
+        )
+        vc.title = title
+        return vc
+      }
 
-      navigationController.push(filesViewController)
+      // Cmd-click / Cmd-double-click on a directory opens it in a new tab,
+      // matching Finder's gesture.
+      let cmdHeld = NSApp.currentEvent?.modifierFlags.contains(.command) ?? false
+      if cmdHeld {
+        (NSApp.delegate as? AppDelegate)?.openInNewTab(adjacentTo: view.window) { nav in
+          nav.push(makeFilesViewController())
+        }
+        return
+      }
+
+      guard let navigationController = navigationController() else { return }
+      navigationController.push(makeFilesViewController())
     } else {
       let treeAccessor = self.treeAccessor
       let path = dirTree.resolvePath(fileNode)

--- a/Examples/FileBrowser/FileBrowser (macOS)/SidebarViewController.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/SidebarViewController.swift
@@ -120,6 +120,12 @@ extension SidebarViewController: NSOutlineViewDelegate {
       return
     }
 
+    // Cmd-click on a sidebar entry opens it in a new tab, matching Finder.
+    // We capture this off NSApp.currentEvent because the selection-change
+    // delegate fires during the click that caused it.
+    let cmdHeld = NSApp.currentEvent?.modifierFlags.contains(.command) ?? false
+    let host = view.window
+
     switch node.content {
     case let serverNode as ServerNode:
       guard let _ = sessionManager.session(for: serverNode.id) else { return }
@@ -135,11 +141,17 @@ extension SidebarViewController: NSOutlineViewDelegate {
           rowView.isSelected = true
         }
 
-        guard let navigationController = navigationController() else { return }
-
         guard let shares: [ShareNode] = DataRepository.shared.nodes(serverNode.path) else { return }
         let sharesViewController = SharesViewController.instantiate(serverNode: serverNode, shares: Tree(nodes: shares))
-        navigationController.push(sharesViewController)
+
+        if cmdHeld {
+          (NSApp.delegate as? AppDelegate)?.openInNewTab(adjacentTo: host) { nav in
+            nav.push(sharesViewController)
+          }
+        } else {
+          guard let navigationController = navigationController() else { return }
+          navigationController.push(sharesViewController)
+        }
       }
     case let shareNode as ShareNode:
       guard let serverNode = sidebarManager.parent(of: node)?.content as? ServerNode else { return }
@@ -157,7 +169,13 @@ extension SidebarViewController: NSOutlineViewDelegate {
         )
         filesViewController.title = shareNode.name
 
-        navigationController()?.push(filesViewController)
+        if cmdHeld {
+          (NSApp.delegate as? AppDelegate)?.openInNewTab(adjacentTo: host) { nav in
+            nav.push(filesViewController)
+          }
+        } else {
+          navigationController()?.push(filesViewController)
+        }
       }
     default:
       break


### PR DESCRIPTION
Mirror Finder's "open in new tab" gesture for both navigation surfaces:

- Cmd-double-click on a directory in the file list opens it in a new tab instead of pushing onto the current navigation stack.
- Cmd-click on a server or share entry in the sidebar opens that destination in a new tab.

To keep the lifecycle of the new windows consistent, add a public `AppDelegate.openInNewTab(adjacentTo:configure:)` helper that:

- instantiates a fresh WindowController from Main.storyboard
- lets the caller push the destination view controller onto the new navigation stack via a `configure` closure
- attaches it as a tab to the supplied existing window
- retains it in the AppDelegate's windowControllers array so it gets released through the existing willCloseNotification cleanup

The Cmd modifier is read from `NSApp.currentEvent?.modifierFlags`, which is the event currently being dispatched — works for the double-click action in FilesViewController and for the selection-change delegate in SidebarViewController without changing their event-handling shape.