### PR TITLE
FileBrowser (macOS): preselect basename only when renaming, like Finder

### DIFF
--- a/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.storyboard
+++ b/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.storyboard
@@ -48,7 +48,7 @@
                                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSActionTemplate" id="h5Y-ZJ-LJD"/>
                                                                 </imageView>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sJI-vE-jmV">
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sJI-vE-jmV" customClass="FilenameTextField" customModule="FileBrowser" customModuleProvider="target">
                                                                     <rect key="frame" x="25" y="0.0" width="149" height="17"/>
                                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
                                                                     <textFieldCell key="cell" lineBreakMode="truncatingMiddle" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" title="Table View Cell" id="QdF-ms-2qB">

--- a/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.swift
@@ -325,9 +325,9 @@ class FilesViewController: NSViewController {
   private func beginEditing(_ row: Int) {
     guard let _ = outlineView.item(atRow: row) as? FileNode else { return }
     // Drive editing through the table-view entry point. The basename-only
-    // initial selection is applied from `controlTextDidBeginEditing(_:)` —
-    // running it from here gets overwritten by AppKit's own select-all
-    // that fires when the field editor attaches.
+    // initial selection is handled by `FilenameTextField` when it becomes
+    // first responder; attempting to force the selection here gets
+    // overwritten by AppKit's own select-all as the field editor attaches.
     outlineView.editColumn(0, row: row, with: nil, select: true)
   }
 

--- a/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.swift
@@ -324,11 +324,11 @@ class FilesViewController: NSViewController {
 
   private func beginEditing(_ row: Int) {
     guard let _ = outlineView.item(atRow: row) as? FileNode else { return }
-
-    guard let rowView = outlineView.rowView(atRow: row, makeIfNecessary: false) else { return }
-    guard let cellView = rowView.view(atColumn: 0) as? NSTableCellView else { return }
-
-    cellView.window?.makeFirstResponder(cellView.textField)
+    // Drive editing through the table-view entry point. The basename-only
+    // initial selection is applied from `controlTextDidBeginEditing(_:)` —
+    // running it from here gets overwritten by AppKit's own select-all
+    // that fires when the field editor attaches.
+    outlineView.editColumn(0, row: row, with: nil, select: true)
   }
 
   @IBAction func deleteMenuAction(_ sender: Any?) {
@@ -758,5 +758,43 @@ func join(_ paths: String...) -> String {
     return paths.dropFirst().joined(separator: "/")
   } else {
     return paths.joined(separator: "/")
+  }
+}
+
+/// NSTextField subclass that mimics Finder's "select basename, leave extension"
+/// behaviour when entering edit mode. AppKit's auto-select-all happens *after*
+/// `NSTextFieldDelegate.controlTextDidBeginEditing(_:)` and after a synchronous
+/// `selectedRange = …` from `becomeFirstResponder()`, so the override has to
+/// dispatch to the next runloop tick on the responder path. The mouse path
+/// already has the field editor installed by the time `super.mouseDown` returns,
+/// so we can update the selection synchronously there.
+///
+/// Reference: CotEditor's FilenameTextField
+/// (https://github.com/coteditor/CotEditor — Apache 2.0).
+class FilenameTextField: NSTextField {
+  override func mouseDown(with event: NSEvent) {
+    super.mouseDown(with: event)
+    currentEditor()?.smbeam_selectFilenameStem()
+  }
+
+  override func becomeFirstResponder() -> Bool {
+    guard super.becomeFirstResponder() else { return false }
+    DispatchQueue.main.async { [weak self] in
+      self?.currentEditor()?.smbeam_selectFilenameStem()
+    }
+    return true
+  }
+}
+
+private extension NSText {
+  /// Selects the filename stem (the portion preceding the trailing
+  /// `.<ext>`). For names without a "real" extension — directories without
+  /// dot-suffixes, dotfiles like `.gitignore`, names like `README` —
+  /// the entire string is selected, matching Finder.
+  func smbeam_selectFilenameStem() {
+    let name = self.string as NSString
+    let stem = (name.deletingPathExtension as NSString)
+    let length = stem.length > 0 ? stem.length : name.length
+    self.selectedRange = NSRange(location: 0, length: length)
   }
 }


### PR DESCRIPTION
When the user starts editing a filename cell — via the Rename menu, the context menu's Rename item, or by clicking into the name — the initial selection now covers just the stem (everything before the final ".ext") instead of the full string. Matches Finder's rename behaviour, so typing replaces only the base name and the extension is preserved.

The fix has to live on a custom NSTextField, not on a delegate or on the table view, because of when AppKit's auto-select-all runs:

* `outlineView.editColumn(_:row:with:select:false)` doesn't actually prevent it for view-based cells.
* `controlTextDidBeginEditing(_:)` fires before the auto-select-all settles; setting `selectedRange` from there (even via `DispatchQueue.main.async`) gets overwritten.

The reliable hook, used by CotEditor's FilenameTextField (Apache 2.0), is:

  * `mouseDown(with:)` — call super, then set the selection synchronously. The field editor is attached by the time super returns, and there's no further select-all on this path.
  * `becomeFirstResponder()` — call super, then dispatch async to main. AppKit runs its select-all on the next runloop turn, and going async puts our selection *after* it so we win.

Add a `FilenameTextField` subclass implementing those two overrides plus an `NSText.smbeam_selectFilenameStem()` helper that uses `NSString.deletingPathExtension` and falls back to "select all" for directories, dotfiles, and extension-less names. Wire it into the NameCell prototype text field via `customClass` in FilesViewController.storyboard.

`beginEditing(_:)` is reduced to `outlineView.editColumn(0, row:row, with: nil, select: true)` and the previous, ineffective `controlTextDidBeginEditing(_:)` override is removed.