### PR TITLE
FileBrowser (macOS): drag-out from outline view downloads to Finder

### DIFF
--- a/Examples/FileBrowser/FileBrowser (macOS)/FileTransfer.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/FileTransfer.swift
@@ -1,3 +1,4 @@
+import AppKit
 import Foundation
 import SMBClient
 
@@ -121,4 +122,150 @@ struct FileUploadUserInfoKey: Hashable, Equatable, RawRepresentable {
 extension FileUploadUserInfoKey {
   static let share = FileUploadUserInfoKey(rawValue: "share")
   static let path = FileUploadUserInfoKey(rawValue: "path")
+}
+
+/// Mirror of `FileUpload` for the drag-out-to-Finder path. The actual byte
+/// stream is performed through the same TransferQueue serial pipeline so
+/// uploads and downloads share the Activities UI and don't trample each
+/// other's SMB session.
+class FileDownload: FileTransfer {
+  let displayName: String
+  var state: TransferState
+  var progressHandler: (_ state: TransferState) -> Void
+
+  let id: UUID
+  private let sourcePath: String
+  private let isDirectory: Bool
+  private let destination: URL
+  private let treeAccessor: TreeAccessor
+
+  init(sourcePath: String, isDirectory: Bool, destination: URL, accessor: TreeAccessor) {
+    id = UUID()
+    self.sourcePath = sourcePath
+    self.isDirectory = isDirectory
+    self.destination = destination
+    treeAccessor = accessor
+    displayName = (sourcePath as NSString).lastPathComponent
+    state = .queued
+    progressHandler = { _ in }
+  }
+
+  func start() async {
+    do {
+      if isDirectory {
+        try await downloadDirectory()
+      } else {
+        try await downloadFile()
+      }
+    } catch {
+      state = .failed(error)
+      progressHandler(state)
+    }
+  }
+
+  private func downloadFile() async throws {
+    let fileReader = try await treeAccessor.fileReader(path: sourcePath)
+    let totalBytes = Int64(try await fileReader.fileSize)
+
+    state = .started(.file(progress: 0, numberOfBytes: totalBytes))
+    progressHandler(state)
+
+    try await fileReader.download(to: destination, overwrite: true) { (progress) in
+      state = .started(.file(progress: progress, numberOfBytes: totalBytes))
+      progressHandler(state)
+    }
+    try await fileReader.close()
+
+    state = .completed(.file(progress: 1, numberOfBytes: totalBytes))
+    progressHandler(state)
+  }
+
+  private func downloadDirectory() async throws {
+    try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+
+    var completed = 0
+    var bytesSent: Int64 = 0
+
+    state = .started(.directory(completedFiles: 0, fileBeingTransferred: nil, bytesSent: 0))
+    progressHandler(state)
+
+    func walk(remoteDir: String, localDir: URL) async throws {
+      let entries = try await treeAccessor.listDirectory(path: remoteDir)
+      for entry in entries where entry.name != "." && entry.name != ".." {
+        let childRemote = remoteDir.isEmpty ? entry.name : "\(remoteDir)/\(entry.name)"
+        let childLocal = localDir.appendingPathComponent(entry.name)
+
+        if entry.isDirectory {
+          try FileManager.default.createDirectory(
+            at: childLocal, withIntermediateDirectories: true
+          )
+          try await walk(remoteDir: childRemote, localDir: childLocal)
+        } else {
+          state = .started(.directory(
+            completedFiles: completed,
+            fileBeingTransferred: childLocal,
+            bytesSent: bytesSent
+          ))
+          progressHandler(state)
+
+          let reader = try await treeAccessor.fileReader(path: childRemote)
+          let size = Int64(try await reader.fileSize)
+          try await reader.download(to: childLocal, overwrite: true)
+          try await reader.close()
+          completed += 1
+          bytesSent += size
+
+          state = .started(.directory(
+            completedFiles: completed,
+            fileBeingTransferred: nil,
+            bytesSent: bytesSent
+          ))
+          progressHandler(state)
+        }
+      }
+    }
+
+    try await walk(remoteDir: sourcePath, localDir: destination)
+
+    state = .completed(.directory(
+      completedFiles: completed,
+      fileBeingTransferred: nil,
+      bytesSent: bytesSent
+    ))
+    progressHandler(state)
+  }
+}
+
+/// NSFilePromiseProvider subclass that also writes the SMB path as a custom
+/// pasteboard type so the existing internal-drag (file move) handler in
+/// FilesViewController can keep recovering the source file from the
+/// dragging pasteboard. External (Finder) drops still use the file-promise
+/// machinery on the `delegate` to materialise the file.
+final class SMBFilePromiseProvider: NSFilePromiseProvider {
+  override func writableTypes(for pasteboard: NSPasteboard) -> [NSPasteboard.PasteboardType] {
+    var types = super.writableTypes(for: pasteboard)
+    types.append(.smbeamSMBPath)
+    return types
+  }
+
+  override func pasteboardPropertyList(forType type: NSPasteboard.PasteboardType) -> Any? {
+    if type == .smbeamSMBPath {
+      if let info = userInfo as? SMBPromiseInfo {
+        return info.smbPath
+      }
+    }
+    return super.pasteboardPropertyList(forType: type)
+  }
+}
+
+/// Strongly typed payload stashed on a `SMBFilePromiseProvider.userInfo`.
+/// `userInfo` is `Any?` on the system class; using a concrete struct here
+/// avoids `[String: Any]` plumbing on every read.
+struct SMBPromiseInfo {
+  let smbPath: String
+  let isDirectory: Bool
+}
+
+extension NSPasteboard.PasteboardType {
+  static let smbeamSMBPath = NSPasteboard.PasteboardType("com.kishikawakatsumi.smbeam.smb-path")
 }

--- a/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.swift
@@ -78,6 +78,13 @@ class FilesViewController: NSViewController {
 
     outlineView.doubleAction = #selector(doubleAction(_:))
     outlineView.registerForDraggedTypes([.fileURL])
+    // Without these, NSOutlineView's drag source defaults to .none for
+    // non-local sessions, which silently kills any drag-out to Finder no
+    // matter what file-promise pasteboard data we write. .move enables the
+    // existing within-outline rename/move; .copy enables the drag-out
+    // download path.
+    outlineView.setDraggingSourceOperationMask(.move, forLocal: true)
+    outlineView.setDraggingSourceOperationMask(.copy, forLocal: false)
 
     for column in outlineView.tableColumns {
       column.sortDescriptorPrototype = NSSortDescriptor(key: column.identifier.rawValue, ascending: true)
@@ -688,10 +695,21 @@ extension FilesViewController: NSOutlineViewDataSource {
   func outlineView(_ outlineView: NSOutlineView, pasteboardWriterForItem item: Any) -> (any NSPasteboardWriting)? {
     guard let fileNode = item as? FileNode else { return nil }
 
-    let pasteboardItem = NSPasteboardItem()
-    pasteboardItem.setString(fileNode.id.rawValue, forType: .fileURL)
-
-    return pasteboardItem
+    // Use NSFilePromiseProvider so dragging a row onto Finder triggers a
+    // download. The custom `.smbeamSMBPath` type is written alongside the
+    // file promise so internal drops within outlineView (= rename/move)
+    // can still recover the SMB path. UTType picks the file's filename
+    // extension so Finder's drop progress UI gets a sensible icon.
+    let utiIdentifier: String
+    if fileNode.isDirectory {
+      utiIdentifier = UTType.folder.identifier
+    } else {
+      let ext = (fileNode.name as NSString).pathExtension
+      utiIdentifier = UTType(filenameExtension: ext)?.identifier ?? UTType.data.identifier
+    }
+    let provider = SMBFilePromiseProvider(fileType: utiIdentifier, delegate: self)
+    provider.userInfo = SMBPromiseInfo(smbPath: fileNode.path, isDirectory: fileNode.isDirectory)
+    return provider
   }
 
   func outlineView(_ outlineView: NSOutlineView, validateDrop info: any NSDraggingInfo, proposedItem item: Any?, proposedChildIndex index: Int) -> NSDragOperation {
@@ -727,30 +745,24 @@ extension FilesViewController: NSOutlineViewDataSource {
   }
 
   func outlineView(_ outlineView: NSOutlineView, acceptDrop info: any NSDraggingInfo, item: Any?, childIndex index: Int) -> Bool {
-    guard let fileURLs = info.draggingPasteboard.readObjects(forClasses: [NSURL.self]) else { return false }
-
     if let _ = info.draggingSource as? NSOutlineView {
+      // Internal drag — moves within the share. Source identity is now
+      // carried on the custom `.smbeamSMBPath` pasteboard type written
+      // alongside the file promise (see SMBFilePromiseProvider).
+      let smbPaths: [String] = (info.draggingPasteboard.pasteboardItems ?? []).compactMap {
+        $0.string(forType: .smbeamSMBPath)
+      }
+      let nodes: [FileNode] = smbPaths.compactMap { dirTree.node(ID($0)) }
+      guard !nodes.isEmpty else { return false }
+
       func validate() -> Bool {
-        for fileURL in fileURLs {
-          guard let fileURL = fileURL as? URL else { return false }
-
-          guard let node = dirTree.node(fileURL) else {
-            return false
-          }
-
+        for node in nodes {
           if let fileNode = item as? FileNode {
-            guard fileNode.isDirectory else {
-              return false
-            }
-            if dirTree.parent(of: node) == fileNode {
-              return false
-            }
-
+            guard fileNode.isDirectory else { return false }
+            if dirTree.parent(of: node) == fileNode { return false }
             return true
           } else {
-            if node.isRoot {
-              return false
-            }
+            if node.isRoot { return false }
             return true
           }
         }
@@ -758,20 +770,10 @@ extension FilesViewController: NSOutlineViewDataSource {
       }
 
       if validate() {
-        for fileURL in fileURLs {
-          guard let fileURL = fileURL as? URL else { return false }
-
-          guard let node = dirTree.node(fileURL) else {
-            return false
-          }
-
+        for node in nodes {
           if let fileNode = item as? FileNode {
-            guard fileNode.isDirectory else {
-              return false
-            }
-            if dirTree.parent(of: node) == fileNode {
-              return false
-            }
+            guard fileNode.isDirectory else { return false }
+            if dirTree.parent(of: node) == fileNode { return false }
 
             Task {
               let basename = URL(fileURLWithPath: node.path).lastPathComponent
@@ -782,9 +784,7 @@ extension FilesViewController: NSOutlineViewDataSource {
             }
             continue
           } else {
-            if node.isRoot {
-              return false
-            }
+            if node.isRoot { return false }
 
             Task {
               let basename = URL(fileURLWithPath: node.path).lastPathComponent
@@ -815,6 +815,9 @@ extension FilesViewController: NSOutlineViewDataSource {
         return false
       }
     } else {
+      // External drag — Finder uploads. NSURLs are still on the pasteboard
+      // because Finder writes them itself.
+      guard let fileURLs = info.draggingPasteboard.readObjects(forClasses: [NSURL.self]) else { return false }
       for fileURL in fileURLs {
         guard let fileURL = fileURL as? URL else { return false }
         let queue = TransferQueue.shared
@@ -1051,6 +1054,84 @@ final class QuickLookItem: NSObject, QLPreviewItem {
 
   var previewItemURL: URL! { localURL }
   var previewItemTitle: String! { title }
+}
+
+// MARK: - Drag-out (file promise)
+
+extension FilesViewController: NSFilePromiseProviderDelegate {
+  /// Returns the on-disk file name Finder should use for the dropped file.
+  /// Finder appends "copy" / number suffixes if a file with that name
+  /// already exists at the drop location, so we don't have to handle
+  /// collisions ourselves.
+  func filePromiseProvider(_ filePromiseProvider: NSFilePromiseProvider, fileNameForType fileType: String) -> String {
+    if let info = filePromiseProvider.userInfo as? SMBPromiseInfo {
+      return (info.smbPath as NSString).lastPathComponent
+    }
+    return "Untitled"
+  }
+
+  /// AppKit invokes this on the queue returned from `operationQueue(for:)`
+  /// once the user drops on a destination. We delegate the actual byte
+  /// streaming to a `FileDownload` queued through `TransferQueue` so the
+  /// Activities panel reflects the work, while reporting completion back
+  /// to AppKit so it can dismiss its drag-progress indicator.
+  func filePromiseProvider(_ filePromiseProvider: NSFilePromiseProvider, writePromiseTo url: URL, completionHandler: @escaping (Error?) -> Void) {
+    guard let info = filePromiseProvider.userInfo as? SMBPromiseInfo else {
+      completionHandler(URLError(.badURL))
+      return
+    }
+
+    let download = FileDownload(
+      sourcePath: info.smbPath,
+      isDirectory: info.isDirectory,
+      destination: url,
+      accessor: treeAccessor
+    )
+
+    // Pre-set a progressHandler that resolves Finder's file promise on
+    // terminal state. TransferQueue.addFileTransfer chains our handler in
+    // front of its own throttled UI handler, so both run.
+    let lock = NSLock()
+    var resolved = false
+    download.progressHandler = { state in
+      let outcome: Result<Void, Error>?
+      switch state {
+      case .completed: outcome = .success(())
+      case .failed(let error): outcome = .failure(error)
+      case .queued, .started: outcome = nil
+      }
+      guard let outcome else { return }
+      lock.lock()
+      if resolved { lock.unlock(); return }
+      resolved = true
+      lock.unlock()
+      switch outcome {
+      case .success: completionHandler(nil)
+      case .failure(let error): completionHandler(error)
+      }
+    }
+
+    Task { @MainActor in
+      TransferQueue.shared.addFileTransfer(download)
+      // Surface the Activities panel so the user sees progress, matching
+      // the upload-on-drop behaviour.
+      NotificationCenter.default.post(name: Self.didStartActivities, object: self)
+    }
+  }
+
+  /// Serial queue used for AppKit's writePromiseTo callbacks. We don't
+  /// actually do work here — the work happens in TransferQueue's actor —
+  /// but AppKit requires a non-main queue so the call doesn't block UI.
+  func operationQueue(for filePromiseProvider: NSFilePromiseProvider) -> OperationQueue {
+    Self.filePromiseQueue
+  }
+
+  private static let filePromiseQueue: OperationQueue = {
+    let queue = OperationQueue()
+    queue.qualityOfService = .userInitiated
+    queue.name = "com.kishikawakatsumi.smbeam.file-promise"
+    return queue
+  }()
 }
 
 extension FilesViewController: NSTextFieldDelegate {

--- a/Examples/FileBrowser/FileBrowser (macOS)/TransferQueue.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/TransferQueue.swift
@@ -28,7 +28,13 @@ class TransferQueue {
 
     Task {
       var fileTransfer = fileTransfer
+      // Preserve any progressHandler the caller set on the transfer before
+      // adding it to the queue (used by the file-promise drag-out path to
+      // detect terminal state). The internal handler we install below
+      // forwards each state update to the caller's handler first.
+      let externalHandler = fileTransfer.progressHandler
       fileTransfer.progressHandler = { (state) in
+        externalHandler(state)
         Task {
           await throttler.throttle {
             await MainActor.run { [weak self] in


### PR DESCRIPTION
Phase 2 of the download story: dragging a file or directory row out of the file list onto Finder, the Desktop, or any external drop target now downloads it through the same TransferQueue pipeline that powers uploads, with progress visible both in Finder's drag HUD and in the Activities panel.

Pieces:

- `SMBFilePromiseProvider`: an `NSFilePromiseProvider` subclass that also writes the SMB path on a custom pasteboard type (`com.kishikawakatsumi.smbeam.smb-path`). This keeps the file promise itself for external drops and at the same time lets the existing internal-drag (= move within share) recover the source SMB path off the same drag.

- `SMBPromiseInfo`: typed `userInfo` payload (smbPath, isDirectory) attached to each provider so the delegate can rebuild the request when AppKit asks for the bytes.

- `FileDownload`: parallel to `FileUpload`, conforming to `FileTransfer`. Single-file path goes through `FileReader.download(to:overwrite:progressHandler:)`. Directory path mkdirs locally then walks `treeAccessor.listDirectory` to download children recursively, reporting `.directory` progress updates so the existing Activities cell shows "<n> files downloaded / current item".

- `FilesViewController.outlineView(_:pasteboardWriterForItem:)` now returns a `SMBFilePromiseProvider` with `userInfo` set, the UTI picked from the file extension (or `UTType.folder` for directories) so Finder shows a sensible drop preview.

- `FilesViewController.outlineView(_:acceptDrop:item:childIndex:)` was reading `NSURL` from the pasteboard for both internal and external sources. The internal branch now reads our custom `.smbeamSMBPath` strings via `pasteboardItems` and resolves them to FileNodes through `dirTree.node(ID(_:))`. The external (Finder uploads) branch continues to read NSURLs as before.

- New `NSFilePromiseProviderDelegate` extension on FilesViewController:
  - `fileNameForType:` — the SMB path's last component (Finder appends "copy"/numeric suffixes itself for collisions, so we don't have to).
  - `writePromiseTo:completionHandler:` — builds a `FileDownload`, pre-installs a progressHandler that resolves Finder's `completionHandler` exactly once on terminal state (NSLock guard), enqueues it on `TransferQueue`, and posts `didStartActivities` so the Activities panel pops up just like the upload-on-drop flow.
  - `operationQueue(for:)` — a static `.userInitiated` serial queue. Required by AppKit; the actual SMB work runs on TransferQueue's actor.

- `TransferQueue.addFileTransfer` previously overwrote `progressHandler` outright, dropping any handler the caller had pre-installed. Capture the externally-set handler and forward to it from the queue's own throttled UI handler so the drag-out delegate can observe terminal state without losing the queue's own progress UI updates.

- `FilesViewController.viewDidLoad` now calls `setDraggingSourceOperationMask(.move, forLocal: true)` and `setDraggingSourceOperationMask(.copy, forLocal: false)` on the outline view. This was the missing piece: without it, `forLocal: false` defaults to `.none`, which silently rejects any drop in another application no matter what's written to the pasteboard — so Finder would happily accept the drag visually but never call `writePromiseTo:`. Setting `.move` for local preserves the existing within-outline move/rename behaviour.

Phase 1 (explicit "Download…" menu items + NSSavePanel/NSOpenPanel for keyboard-driven downloads) is intentionally still pending and will follow later.