### PR TITLE
FileBrowser (macOS): keep Quick Look video overlay opaque during NAS …

### DIFF
--- a/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.swift
+++ b/Examples/FileBrowser/FileBrowser (macOS)/FilesViewController.swift
@@ -369,6 +369,18 @@ class FilesViewController: NSViewController {
       quickLookPlayerView = playerView
     }
 
+    // Quick Look's preview engine may insert its own "couldn't preview"
+    // view on top of contentView a moment after we add our overlay (the
+    // placeholder file we hand to QLPreviewItem is empty, so it errors).
+    // Reassert the overlay's z-order over the next couple of seconds so
+    // it stays on top regardless of when QL's error view appears.
+    ensureQuickLookOverlayOnTop()
+    for delay in [0.05, 0.15, 0.5, 1.5, 3.0] {
+      DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+        self?.ensureQuickLookOverlayOnTop()
+      }
+    }
+
     // Tear down previous asset before installing the new one. SMBAVAsset.close()
     // closes the underlying FileReader, so we don't leak SMB handles when
     // arrow-keying through a list of videos.
@@ -382,17 +394,16 @@ class FilesViewController: NSViewController {
     quickLookCurrentAsset = asset
     quickLookCurrentVideoPath = smbPath
 
-    // Mirror MediaPlayerWindowController.windowDidLoad: read a single byte
-    // through a freshly opened FileReader before handing the SMBAVAsset to
-    // AVPlayer. Sleeping NAS disks block this read at the SMB layer until
-    // they spin up, which is the cleanest way to gate AVPlayer setup.
-    // Without this, AVPlayer's first metadata fetch fails fast on a
-    // sleeping disk and Quick Look stays on a black overlay with no
-    // recovery path (AVPlayer doesn't retry on its own).
+    // Warmup: read a real chunk before letting AVPlayer touch the asset.
+    // 1-byte reads can return immediately from a NAS metadata cache on
+    // some implementations without ever hitting the platters; using the
+    // default read length (≈ maxReadSize, ~1 MB) forces a real fetch and
+    // therefore reliably blocks server-side until the disk has spun up.
+    // Same pattern as MediaPlayerWindowController.windowDidLoad.
     Task { @MainActor [weak self, treeAccessor, smbPath, asset] in
       do {
         let reader = try await treeAccessor.fileReader(path: smbPath)
-        _ = try await reader.read(offset: 0, length: 1)
+        _ = try await reader.read(offset: 0)
         try await reader.close()
       } catch {
         return  // Couldn't reach the file at all; bail silently.
@@ -405,9 +416,23 @@ class FilesViewController: NSViewController {
       let player = AVPlayer(playerItem: playerItem)
       self.quickLookPlayerView?.player = player
       player.play()
+      // Re-promote one more time post-warmup to cover late QL views.
+      self.ensureQuickLookOverlayOnTop()
 
       self.resizeQuickLookPanelToVideoSize(of: asset)
     }
+  }
+
+  /// Re-pin the AVPlayerView overlay to the top of `panel.contentView`'s
+  /// subview stack. Cheap enough to call repeatedly from delayed dispatches.
+  private func ensureQuickLookOverlayOnTop() {
+    guard let panel = QLPreviewPanel.shared(),
+          panel.isVisible,
+          let containerView = panel.contentView,
+          let overlay = quickLookPlayerView,
+          overlay.superview === containerView
+    else { return }
+    containerView.addSubview(overlay, positioned: .above, relativeTo: nil)
   }
 
   /// Resize the QLPreviewPanel to fit the video's natural dimensions, capped


### PR DESCRIPTION
…spin-up

The video Quick Look path was still occasionally flashing Quick Look's "couldn't preview" view at the user while the NAS disk was spinning up. Two combined causes, both addressed here:

1. The warmup read used `read(offset: 0, length: 1)`. Some NAS implementations satisfy a 1-byte read straight from the SMB metadata cache without ever spinning the platters, so the warmup returned before the disk was actually awake — leaving AVPlayer to fail-fast on the first metadata fetch a beat later. Switch the warmup to `read(offset: 0)`, which uses the full default read length (≈ maxReadSize, ~1 MB) and forces a real on-disk fetch, so the SMB Read reliably blocks server-side until the platters respond.

2. The black `AVPlayerView` overlay we install on `panel.contentView` was added with `addSubview(_:positioned: .above, relativeTo: nil)`, which only makes it topmost at that instant. Quick Look's preview engine tries to render the empty placeholder file we hand to `QLPreviewItem`, fails, and then inserts its "couldn't preview" view onto contentView a few moments later — landing on top of our overlay in z-order and exposing the error to the user.

   Add an `ensureQuickLookOverlayOnTop()` helper that reasserts the overlay's z-order and call it right after install plus on delayed dispatches at 0.05 / 0.15 / 0.5 / 1.5 / 3.0 seconds, and once more after the warmup completes. This catches QL's late-arriving subviews regardless of when they get inserted during the spin-up wait window, so the black overlay stays visible until playback actually starts.

Same warmup-read pattern as `MediaPlayerWindowController`; the double-click playback path already worked because the user retrying it masks any underlying issue.